### PR TITLE
Added Email Template support for Send Email Action

### DIFF
--- a/sendgrid/connector.py
+++ b/sendgrid/connector.py
@@ -1,8 +1,9 @@
-""" Copyright start
-  Copyright (C) 2008 - 2025 Fortinet Inc.
-  All rights reserved.
-  FORTINET CONFIDENTIAL & FORTINET PROPRIETARY SOURCE CODE
-  Copyright end """
+"""
+Copyright start
+MIT License
+Copyright (c) 2025 Fortinet Inc
+Copyright end
+"""
 
 from connectors.core.connector import Connector, ConnectorError, get_logger
 from .operations import operations, check_health

--- a/sendgrid/connector.py
+++ b/sendgrid/connector.py
@@ -1,5 +1,5 @@
 """ Copyright start
-  Copyright (C) 2008 - 2021 Fortinet Inc.
+  Copyright (C) 2008 - 2025 Fortinet Inc.
   All rights reserved.
   FORTINET CONFIDENTIAL & FORTINET PROPRIETARY SOURCE CODE
   Copyright end """
@@ -13,7 +13,7 @@ class Sendgrid(Connector):
     def execute(self, config, operation, params, **kwargs):
         try:
             action = operations.get(operation)
-            return action(config, params)
+            return action(config, params, **kwargs)
         except Exception as err:
             logger.exception(str(err))
             raise ConnectorError(str(err))

--- a/sendgrid/constants.py
+++ b/sendgrid/constants.py
@@ -1,3 +1,10 @@
+""" Copyright start
+  Copyright (C) 2008 - 2025 Fortinet Inc.
+  All rights reserved.
+  FORTINET CONFIDENTIAL & FORTINET PROPRIETARY SOURCE CODE
+  Copyright end """
+
+
 SCHDULED_ENDPOINT = '/user/scheduled_sends'
 CONTACT_LIST_ENDPOINT = '/marketing/lists'
 ALERT_ENDPOINT = '/alerts'

--- a/sendgrid/constants.py
+++ b/sendgrid/constants.py
@@ -1,9 +1,9 @@
-""" Copyright start
-  Copyright (C) 2008 - 2025 Fortinet Inc.
-  All rights reserved.
-  FORTINET CONFIDENTIAL & FORTINET PROPRIETARY SOURCE CODE
-  Copyright end """
-
+"""
+Copyright start
+MIT License
+Copyright (c) 2025 Fortinet Inc
+Copyright end
+"""
 
 SCHDULED_ENDPOINT = '/user/scheduled_sends'
 CONTACT_LIST_ENDPOINT = '/marketing/lists'

--- a/sendgrid/info.json
+++ b/sendgrid/info.json
@@ -1,15 +1,15 @@
 {
   "name": "sendgrid",
   "label": "SendGrid",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "SendGrid",
-  "publisher": "Community",
+  "publisher": "Fortinet",
   "cs_approved": false,
   "cs_compatible": true,
   "category": "Email Server",
   "icon_small_name": "small.png",
   "icon_large_name": "large.png",
-  "help_online": "https://docs.fortinet.com/document/fortisoar/1.0.0/sendgrid/177/sendgrid-v1-0-0",
+  "help_online": "",
   "configuration": {
     "fields": [
       {
@@ -55,7 +55,7 @@
       "parameters": [
         {
           "title": "From",
-          "tooltip": "The 'From' email address used to deliver the message",
+          "tooltip": "The email ID of the sender from whose account you want to send the email. This address must be a verified sender in your SendGrid account.",
           "required": true,
           "editable": true,
           "visible": true,
@@ -65,17 +65,17 @@
         },
         {
           "title": "To Recipients",
-          "tooltip": "The email address of the recipients, in csv or list format",
+          "tooltip": "The email IDs of the recipients, in CSV or list format, to whose account you want to deliver the email.",
           "required": true,
           "editable": true,
           "visible": true,
           "type": "email",
           "name": "to_emails",
-          "description": "The email IDs of the recipients, in CSV or list format, towhose account you want to deliver the email."
+          "description": "The email IDs of the recipients, in CSV or list format, to whose account you want to deliver the email."
         },
         {
           "title": "CC Recipients",
-          "tooltip": "CSV / List Format",
+          "tooltip": "The email IDs of the members, in CSV or list format, that you want to add to the CC list of the email.",
           "description": "(Optional) The email IDs of the members, in CSV or list format, that you want to add to the CC list of the email.",
           "required": false,
           "editable": true,
@@ -94,34 +94,67 @@
           "name": "bcc_recipients"
         },
         {
-          "title": "Subject",
-          "tooltip": "The subject of your email",
-          "required": false,
-          "editable": true,
+          "title": "Body Type",
+          "name": "body_type",
+          "type": "select",
+          "options": [
+            "Rich Text",
+            "Email Template"
+          ],
           "visible": true,
-          "type": "text",
-          "name": "subject",
-          "description": "(Optional) The subject of your email that you want to send using your SendGrid account."
-        },
-        {
-          "title": "Plain Text Body Content",
-          "tooltip": "The plain text body of the email",
-          "required": false,
           "editable": true,
-          "visible": true,
-          "type": "text",
-          "name": "plain_text_content",
-          "description": "(Optional) The body of the email in plain text, which you want to send using your SendGrid account."
-        },
-        {
-          "title": "HTML Body Content",
-          "tooltip": "The html body of the email",
-          "required": false,
-          "editable": true,
-          "visible": true,
-          "type": "text",
-          "name": "html_content",
-          "description": "(Optional) The body of the email in HTML, which you want to send using your SendGrid account."
+          "required": true,
+          "description": "Select the format in which you want to send the email. You can choose from the following options: Rich Text, or Email Template.\nIf you choose Rich Text, then in the Content field, you can add formatted content, images, and even custom jinja expressions using Dynamic Values.\nIf you choose Email Template, then the Email Template drop-down list is displayed, using which you can select the template that you want to use to send the email. An existing email template is passed as an input for the email subject and body (content) allowing you to leverage an existing email template and build upon it, thereby, avoiding re-work and ensuring consistency.",
+          "tooltip": "Select the format in which you want to send the email.",
+          "onchange": {
+            "Rich Text": [
+              {
+                "title": "Subject",
+                "name": "subject",
+                "type": "text",
+                "tooltip": "The subject of your email that you want to send using your SendGrid account.",
+                "description": "The subject of your email that you want to send using your SendGrid account.",
+                "required": true,
+                "editable": true,
+                "visible": true
+              },
+              {
+                "title": "Plain Text Body Content",
+                "name": "plain_text_content",
+                "type": "text",
+                "tooltip": "The body of the email in plain text, which you want to send using your SendGrid account.",
+                "description": "The body of the email in plain text, which you want to send using your SendGrid account.",
+                "required": false,
+                "editable": true,
+                "visible": true
+              },
+              {
+                "title": "HTML Body Content",
+                "tooltip": "The body of the email in HTML, which you want to send using your SendGrid account.",
+                "required": false,
+                "editable": true,
+                "visible": true,
+                "type": "richtext",
+                "renderer_type": "html",
+                "name": "html_content",
+                "description": "(Optional) The body of the email in HTML, which you want to send using your SendGrid account."
+              }
+            ],
+            "Email Template": [
+              {
+                "title": "Email Template",
+                "name": "email_templates",
+                "type": "select",
+                "apiOperation": "get_email_templates",
+                "visible": true,
+                "editable": true,
+                "required": true,
+                "tooltip": "Select a template, in the Email Template field, to use when sending emails to users.",
+                "description": "Select a template, in the Email Template field, to use when sending emails to users."
+              }
+            ]
+          },
+          "value": "Rich Text"
         },
         {
           "title": "Attachment IRIs",
@@ -575,6 +608,18 @@
         }
       ],
       "enabled": true
+    },
+    {
+      "operation": "get_email_templates",
+      "title": "Get Email Templates",
+      "description": "Get available email templates",
+      "category": "investigation",
+      "annotation": "get_email_templates",
+      "is_config_required": false,
+      "output_schema": {},
+      "enabled": true,
+      "visible": false,
+      "parameters": []
     }
   ]
 }

--- a/sendgrid/operations.py
+++ b/sendgrid/operations.py
@@ -1,8 +1,9 @@
-""" Copyright start
-  Copyright (C) 2008 - 2025 Fortinet Inc.
-  All rights reserved.
-  FORTINET CONFIDENTIAL & FORTINET PROPRIETARY SOURCE CODE
-  Copyright end """
+"""
+Copyright start
+MIT License
+Copyright (c) 2025 Fortinet Inc
+Copyright end
+"""
 
 import requests, json, base64
 from os.path import join

--- a/sendgrid/operations.py
+++ b/sendgrid/operations.py
@@ -1,11 +1,10 @@
 """ Copyright start
-  Copyright (C) 2008 - 2021 Fortinet Inc.
+  Copyright (C) 2008 - 2025 Fortinet Inc.
   All rights reserved.
   FORTINET CONFIDENTIAL & FORTINET PROPRIETARY SOURCE CODE
   Copyright end """
 
 import requests, json, base64
-import mimetypes
 from os.path import join
 from .constants import *
 from sendgrid import SendGridAPIClient
@@ -13,7 +12,7 @@ from connectors.cyops_utilities.builtins import download_file_from_cyops
 from integrations.crudhub import make_request, make_file_upload_request
 from sendgrid.helpers.mail import (Mail, Attachment, FileContent, FileName, Disposition, BatchId, SendAt, To, Bcc, Cc, From, Content, Subject, FileType)
 
-
+from connectors.environment import expand
 from connectors.core.connector import ConnectorError, get_logger
 
 logger = get_logger('sendgrid')
@@ -130,22 +129,27 @@ def _handle_attachments(iri_list, message, inline=False):
         raise ConnectorError(str(err))
 
 
-def send_email(config, params):
+def send_email(config, params, **kwargs):
     try:
+        env = kwargs.get('env', {})
         params = {k: v for k, v in params.items() if v is not None and v != '' and v != {}}
         message = Mail()
-
         if not params.get('html_content') and not params.get('plain_text_content'):
             raise ConnectorError('At least one parameter is required from \'Plain Text Body Content\' or \'HTML Body Content\'')
         message.from_email = From(params.get('from_email'))
-        if params.get('subject'):
+        if params.get('body_type') == 'Email Template':
+            email_template = params.get('email_templates')
+            subject, body = _email_template_handler(email_template, env=env)
+            message.content = Content('text/html', body)
+        else:
+            subject = str(params.get('subject'))
+            if params.get('html_content'):
+                message.content = Content('text/html', params.get('html_content'))
+            if params.get('plain_text_content'):
+                message.content = Content('text/plain', params.get('plain_text_content'))
+        if subject:
             message.subject = Subject(params.get('subject'))
 
-        if params.get('html_content'):
-            message.content = Content('text/html', params.get('html_content'))
-
-        if params.get('plain_text_content'):
-            message.content = Content('text/plain', params.get('plain_text_content'))
 
         _handle_attachments(str_to_list(params.get('iri_list')), message)
         _handle_attachments(str_to_list(params.get('inline_iri_list')), message, True)
@@ -187,7 +191,7 @@ def send_email(config, params):
         raise ConnectorError(str(err))
 
 
-def get_email_stats(config, params):
+def get_email_stats(config, params, **kwargs):
     try:
         endpoint = ENDPOINTS_DICT.get(params.pop('stats_by'))
         sendgrid_obj = SendGrid(config)
@@ -203,7 +207,7 @@ def get_email_stats(config, params):
         raise ConnectorError(str(err))
 
 
-def search_email(config, params):
+def search_email(config, params, **kwargs):
     try:
         sendgrid_obj = SendGrid(config)
         endpoint = '/messages'
@@ -218,7 +222,7 @@ def search_email(config, params):
         raise ConnectorError(str(err))
 
 
-def get_contact_list(config, params):
+def get_contact_list(config, params, **kwargs):
     try:
         sendgrid_obj = SendGrid(config)
         return sendgrid_obj.make_rest_call(CONTACT_LIST_ENDPOINT)
@@ -227,7 +231,7 @@ def get_contact_list(config, params):
         raise ConnectorError(str(err))
 
 
-def get_alerts(config, params):
+def get_alerts(config, params, **kwargs):
     try:
         sendgrid_obj = SendGrid(config)
         return sendgrid_obj.make_rest_call(ALERT_ENDPOINT)
@@ -236,7 +240,7 @@ def get_alerts(config, params):
         raise ConnectorError(str(err))
 
 
-def create_batch_id(config, params):
+def create_batch_id(config, params, **kwargs):
     try:
         sendgrid_obj = SendGrid(config)
         return sendgrid_obj.make_rest_call(CREATE_BATCH_ENDPOINT, method='POST')
@@ -245,7 +249,7 @@ def create_batch_id(config, params):
         raise ConnectorError(str(err))
 
 
-def get_scheduled_send(config, params):
+def get_scheduled_send(config, params, **kwargs):
     try:
         sendgrid_obj = SendGrid(config)
         if params.get('batch_id'):
@@ -259,7 +263,7 @@ def get_scheduled_send(config, params):
         raise ConnectorError(str(err))
 
 
-def update_scheduled_send(config, params):
+def update_scheduled_send(config, params, **kwargs):
     try:
         sendgrid_obj = SendGrid(config)
         data = {
@@ -272,7 +276,7 @@ def update_scheduled_send(config, params):
         raise ConnectorError(str(err))
 
 
-def delete_scheduled_send(config, params):
+def delete_scheduled_send(config, params, **kwargs):
     try:
         sendgrid_obj = SendGrid(config)
         endpoint = SCHDULED_ENDPOINT + '/{batch_id}'.format(batch_id=params.get('batch_id'))
@@ -280,6 +284,30 @@ def delete_scheduled_send(config, params):
     except Exception as err:
         logger.exception(str(err))
         raise ConnectorError(str(err))
+
+def _email_template_handler(email_template, env={}):
+    request_body = {'logic': 'OR', 'filters': [{'field': 'name', 'operator': 'eq', 'value': email_template}]}
+    response = make_request('/api/query/email_templates', 'POST', body=request_body)['hydra:member']
+    subject = ''
+    content = ''
+    if response:
+        subject = response[0]['subject']
+        content = response[0]['content']
+        try:
+            subject = expand(env, subject)
+            content = expand(env, content)
+        except Exception as err:
+            logger.error('err: {}'.format(err))
+            raise ConnectorError(err)
+    return subject, content
+
+def get_email_templates(config, params, **kwargs):
+    email_template_names = []
+    response = make_request('/api/3/email_templates', 'GET')['hydra:member']
+    for email_template in response:
+        email_template_names.append(email_template['name'])
+    return email_template_names
+
 
 
 def check_health(config):
@@ -303,5 +331,6 @@ operations = {
     'create_batch_id': create_batch_id,
     'get_scheduled_send': get_scheduled_send,
     'update_scheduled_send': update_scheduled_send,   
-    'delete_scheduled_send': delete_scheduled_send 
+    'delete_scheduled_send': delete_scheduled_send,
+    'get_email_templates': get_email_templates
 }

--- a/sendgrid/playbooks/playbooks.json
+++ b/sendgrid/playbooks/playbooks.json
@@ -3,7 +3,7 @@
   "data": [
     {
       "@type": "WorkflowCollection",
-      "name": "Sample - SendGrid - 1.0.0",
+      "name": "Sample - SendGrid - 1.1.0",
       "description": null,
       "visible": true,
       "image": null,
@@ -59,7 +59,7 @@
                 "name": "SendGrid",
                 "config": "991cbe5d-c166-4f9e-84c8-5da16233718e",
                 "params": [],
-                "version": "1.0.0",
+                "version": "1.1.0",
                 "connector": "sendgrid",
                 "operation": "create_batch_id",
                 "operationTitle": "Create Batch ID",
@@ -148,7 +148,7 @@
                   "start_date": "2021-09-14T18:30:00.000Z",
                   "aggregated_by": ""
                 },
-                "version": "1.0.0",
+                "version": "1.1.0",
                 "connector": "sendgrid",
                 "operation": "get_email_stats",
                 "operationTitle": "Get Email Statistics",
@@ -235,7 +235,7 @@
                   "status": "Cancel",
                   "batch_id": "NTU0YTFmMzMtMTZlNS0xMWVjLWJmOWEtYTYyY2Y3YWI5NWM0LWU3N2NlYjc2Ng"
                 },
-                "version": "1.0.0",
+                "version": "1.1.0",
                 "connector": "sendgrid",
                 "operation": "update_scheduled_send",
                 "operationTitle": "Update Scheduled Send",
@@ -319,7 +319,7 @@
                 "name": "SendGrid",
                 "config": "991cbe5d-c166-4f9e-84c8-5da16233718e",
                 "params": [],
-                "version": "1.0.0",
+                "version": "1.1.0",
                 "connector": "sendgrid",
                 "operation": "get_contact_list",
                 "operationTitle": "Get Contact List",
@@ -403,7 +403,7 @@
                 "name": "SendGrid",
                 "config": "991cbe5d-c166-4f9e-84c8-5da16233718e",
                 "params": [],
-                "version": "1.0.0",
+                "version": "1.1.0",
                 "connector": "sendgrid",
                 "operation": "get_scheduled_send",
                 "operationTitle": "Get Scheduled Send",
@@ -464,7 +464,7 @@
                   "limit": "",
                   "query": "subject=test email from sendgrid server"
                 },
-                "version": "1.0.0",
+                "version": "1.1.0",
                 "connector": "sendgrid",
                 "operation": "search_email",
                 "operationTitle": "Search Emails",
@@ -550,7 +550,7 @@
                 "params": {
                   "batch_id": "NTU0YTFmMzMtMTZlNS0xMWVjLWJmOWEtYTYyY2Y3YWI5NWM0LWU3N2NlYjc2Ng"
                 },
-                "version": "1.0.0",
+                "version": "1.1.0",
                 "connector": "sendgrid",
                 "operation": "delete_scheduled_send",
                 "operationTitle": "Delete Scheduled Send",
@@ -634,7 +634,7 @@
                 "name": "SendGrid",
                 "config": "991cbe5d-c166-4f9e-84c8-5da16233718e",
                 "params": [],
-                "version": "1.0.0",
+                "version": "1.1.0",
                 "connector": "sendgrid",
                 "operation": "get_alerts",
                 "operationTitle": "Get Alerts",
@@ -730,7 +730,7 @@
                   "inline_iri_list": "",
                   "plain_text_content": "plain content of body"
                 },
-                "version": "1.0.0",
+                "version": "1.1.0",
                 "connector": "sendgrid",
                 "operation": "send_email",
                 "operationTitle": "Send Email",

--- a/sendgrid/release_notes.md
+++ b/sendgrid/release_notes.md
@@ -1,0 +1,6 @@
+#### What's Improved
+#### Following enhancements have been made to the SendGrid Connector in version 1.1.0: 
+- Added support for `Email Templates` in the `Send Email` action.
+  - Added a new parameter `Body Type` for the `Send Email` actions with following options:
+      - `Rich Text`
+      - `Email Template`


### PR DESCRIPTION
Mantis: https://mantis.fortinet.com/bug_resolve_page.php
Fix Details:
- Added support for Email Templates in the action Send Email (only available in FortiSOAR™ v7.6.5 and later).
  - Added a new parameter `Body Type` for the action `Send Email` with the following options:
      - `Rich Text`
      - `Email Template`
----
UTC:
----
1. Verified whether the email template variables are evaluated properly.
2. Verified that the HTML tags display the correct font, size, color, tables, etc., properly.
3. Upgrade Path: Verified that the send email action is working as expected on the upgrade path without any changes to parameters.